### PR TITLE
add bower as a dependency, autoinstall after npm install

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -49,12 +49,14 @@
   },
   "description": "A module (mod, s3m, it, xm) desktop player",
   "dependencies": {
+    "bower": "^1.7.9",
     "download": "^4.2.1",
     "html-entities": "^1.1.3",
     "walkdir": "^0.0.10"
   },
   "private": true,
   "scripts": {
+    "postinstall": "bower install",
     "test": "echo \"No tests to run\" && exit 0",
     "start": "./start.sh"
   },


### PR DESCRIPTION
This is a very simple but cool thing that allows people that don't have Bower installed to work on the project. This PR is just a suggestion.
